### PR TITLE
New frame

### DIFF
--- a/css/public_analytics.css
+++ b/css/public_analytics.css
@@ -1,4 +1,4 @@
-@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700,300);
+@import url(//fonts.googleapis.com/css?family=Open+Sans:400,700,300);
 html {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
@@ -10,7 +10,7 @@ html {
   box-sizing: inherit; }
 
 body {
-  font-family: "Source Sans Pro", Helvetica, arial, sans-serif;
+  font-family: "Open Sans", Helvetica, arial, sans-serif;
   background: #fff;
   margin: 0; }
 
@@ -61,29 +61,9 @@ header {
       width: 25%;
       padding: 0; }
 
-section {
-  float: left;
-  display: block;
-  margin-right: 2.35765%;
-  width: 100%; }
-  section:last-child {
-    margin-right: 0; }
-  section h2 {
-    font-size: 4em;
-    float: left;
-    display: block;
-    margin-right: 2.35765%;
-    width: 57.35098%;
-    margin: 0; }
-    section h2:last-child {
-      margin-right: 0; }
-  section p {
-    float: left;
-    display: block;
-    margin-right: 2.35765%;
-    width: 65.88078%; }
-    section p:last-child {
-      margin-right: 0; }
+section h2 {
+  font-size: 8em;
+  margin: 0; }
 
 .container {
   max-width: 68em;
@@ -95,8 +75,41 @@ section {
     content: "";
     display: table; }
 
+#main_data {
+  float: left;
+  display: block;
+  margin-right: 2.35765%;
+  width: 74.41059%; }
+  #main_data:last-child {
+    margin-right: 0; }
+
+#secondary_data {
+  float: left;
+  display: block;
+  margin-right: 2.35765%;
+  width: 23.23176%;
+  background: #f9f9f9; }
+  #secondary_data:last-child {
+    margin-right: 0; }
+
+.three_column {
+  float: left;
+  display: block;
+  margin-right: 3.16844%;
+  width: 31.22104%; }
+  .three_column:last-child {
+    margin-right: 0; }
+
+#time_series {
+  text-align: center;
+  margin-bottom: 60px; }
+  #time_series .chart_subtitle {
+    font-size: 3em;
+    font-weight: 300; }
+
 #big_number {
-  color: #921B1E; }
+  color: #921B1E;
+  text-align: center; }
 
 figure {
   margin: 0; }

--- a/css/public_analytics.css
+++ b/css/public_analytics.css
@@ -1,4 +1,4 @@
-@import url(//fonts.googleapis.com/css?family=Open+Sans:400,700,300);
+@import url(//fonts.googleapis.com/css?family=Open+Sans:400,600,700,300);
 html {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
@@ -21,7 +21,8 @@ form .hidden {
   display: none; }
 
 header {
-  background: #36435A; }
+  background: #36435A;
+  color: white; }
   header .header_container {
     max-width: 68em;
     margin-left: auto;
@@ -34,32 +35,31 @@ header {
   header #color_bar {
     background: #3A96B7;
     height: 6px; }
-  header #logo {
-    height: 60px; }
   header h1 {
     float: left;
     display: block;
     margin-right: 2.35765%;
-    width: 57.35098%; }
+    width: 57.35098%;
+    font-weight: 300; }
     header h1:last-child {
       margin-right: 0; }
-  header form {
+    header h1 a {
+      font-weight: 600;
+      color: white;
+      text-decoration: none; }
+    header h1 a:hover {
+      text-decoration: underline; }
+  header #datetime {
+    font-size: 1em;
+    font-weight: 300;
     float: left;
     display: block;
     margin-right: 2.35765%;
     width: 40.29137%;
-    margin: 35px 0;
-    height: 40px; }
-    header form:last-child {
+    padding-top: 2em;
+    text-align: right; }
+    header #datetime:last-child {
       margin-right: 0; }
-    header form input {
-      height: 40px;
-      font-size: 1em; }
-    header form input.query {
-      width: 70%; }
-    header form input.submit {
-      width: 25%;
-      padding: 0; }
 
 section h2 {
   font-size: 8em;

--- a/css/public_analytics.css
+++ b/css/public_analytics.css
@@ -17,6 +17,19 @@ body {
 h2 {
   font-size: 4em; }
 
+h3 {
+  font-size: 1.2em;
+  margin: 1em 0; }
+
+h4 {
+  margin: 1em 0;
+  font-size: 1.2em;
+  font-weight: 400; }
+
+h5 {
+  font-size: 0.8em;
+  font-weight: 400; }
+
 header {
   background: #36435A;
   color: white; }
@@ -72,7 +85,7 @@ header {
     float: left;
     display: block;
     margin-right: 2.01406%;
-    width: 34.41953%;
+    width: 48.99297%;
     padding-top: 2em;
     text-align: right; }
     header #datetime:last-child {
@@ -147,6 +160,9 @@ section h2 {
       #secondary_data:last-child {
         margin-right: 0; } }
 
+.section_headline {
+  border-top: 1px solid #ccc; }
+
 .three_column {
   float: left;
   display: block;
@@ -162,6 +178,12 @@ section h2 {
       width: 100%; }
       .three_column:last-child {
         margin-right: 0; } }
+  .three_column h4 {
+    text-align: center;
+    margin: 0; }
+  .three_column h5 {
+    margin-top: 0;
+    text-align: center; }
 
 #time_series {
   text-align: center;

--- a/css/public_analytics.css
+++ b/css/public_analytics.css
@@ -17,14 +17,11 @@ body {
 h2 {
   font-size: 4em; }
 
-form .hidden {
-  display: none; }
-
 header {
   background: #36435A;
   color: white; }
   header .header_container {
-    max-width: 68em;
+    max-width: 1560px;
     margin-left: auto;
     margin-right: auto;
     padding: 0 1em; }
@@ -32,6 +29,18 @@ header {
       clear: both;
       content: "";
       display: table; }
+    @media screen and (max-width: 1600px) {
+      header .header_container {
+        max-width: 1560px; } }
+    @media screen and (max-width: 1200px) {
+      header .header_container {
+        max-width: 1170px; } }
+    @media screen and (max-width: 992px) {
+      header .header_container {
+        max-width: 970px; } }
+    @media screen and (max-width: 768px) {
+      header .header_container {
+        max-width: 750px; } }
   header #color_bar {
     background: #3A96B7;
     height: 6px; }
@@ -49,6 +58,14 @@ header {
       text-decoration: none; }
     header h1 a:hover {
       text-decoration: underline; }
+    @media screen and (max-width: 768px) {
+      header h1 {
+        float: left;
+        display: block;
+        margin-right: 38.19821%;
+        width: 100%; }
+        header h1:last-child {
+          margin-right: 0; } }
   header #datetime {
     font-size: 1em;
     font-weight: 300;
@@ -60,13 +77,23 @@ header {
     text-align: right; }
     header #datetime:last-child {
       margin-right: 0; }
+    @media screen and (max-width: 768px) {
+      header #datetime {
+        float: left;
+        display: block;
+        margin-right: 38.19821%;
+        width: 100%;
+        text-align: left;
+        padding-top: 0; }
+        header #datetime:last-child {
+          margin-right: 0; } }
 
 section h2 {
   font-size: 8em;
   margin: 0; }
 
 .container {
-  max-width: 68em;
+  max-width: 1560px;
   margin-left: auto;
   margin-right: auto;
   padding: 1em; }
@@ -74,6 +101,18 @@ section h2 {
     clear: both;
     content: "";
     display: table; }
+  @media screen and (max-width: 1600px) {
+    .container {
+      max-width: 1560px; } }
+  @media screen and (max-width: 1200px) {
+    .container {
+      max-width: 1170px; } }
+  @media screen and (max-width: 992px) {
+    .container {
+      max-width: 970px; } }
+  @media screen and (max-width: 768px) {
+    .container {
+      max-width: 750px; } }
 
 #main_data {
   float: left;
@@ -82,6 +121,14 @@ section h2 {
   width: 74.41059%; }
   #main_data:last-child {
     margin-right: 0; }
+  @media screen and (max-width: 768px) {
+    #main_data {
+      float: left;
+      display: block;
+      margin-right: 38.19821%;
+      width: 100%; }
+      #main_data:last-child {
+        margin-right: 0; } }
 
 #secondary_data {
   float: left;
@@ -91,6 +138,14 @@ section h2 {
   background: #f9f9f9; }
   #secondary_data:last-child {
     margin-right: 0; }
+  @media screen and (max-width: 768px) {
+    #secondary_data {
+      float: left;
+      display: block;
+      margin-right: 38.19821%;
+      width: 100%; }
+      #secondary_data:last-child {
+        margin-right: 0; } }
 
 .three_column {
   float: left;
@@ -99,6 +154,14 @@ section h2 {
   width: 31.22104%; }
   .three_column:last-child {
     margin-right: 0; }
+  @media screen and (max-width: 768px) {
+    .three_column {
+      float: left;
+      display: block;
+      margin-right: 38.19821%;
+      width: 100%; }
+      .three_column:last-child {
+        margin-right: 0; } }
 
 #time_series {
   text-align: center;
@@ -108,7 +171,7 @@ section h2 {
     font-weight: 300; }
 
 #big_number {
-  color: #3A96B7;
+  font-weight: 600;
   text-align: center; }
 
 figure {

--- a/css/public_analytics.css
+++ b/css/public_analytics.css
@@ -12,6 +12,7 @@ html {
 body {
   font-family: "Open Sans", Helvetica, arial, sans-serif;
   font-size: 16px;
+  font-weight: 300;
   background: #fff;
   margin: 0; }
   @media screen and (max-width: 992px) {

--- a/css/public_analytics.css
+++ b/css/public_analytics.css
@@ -222,5 +222,3 @@ table.data {
       top: 100%; }
     .stack .bin:last-child .label, .stack .bin:last-child .value {
       right: 0; }
-
-/*# sourceMappingURL=public_analytics.css.map */

--- a/css/public_analytics.css
+++ b/css/public_analytics.css
@@ -11,8 +11,15 @@ html {
 
 body {
   font-family: "Open Sans", Helvetica, arial, sans-serif;
+  font-size: 16px;
   background: #fff;
   margin: 0; }
+  @media screen and (max-width: 992px) {
+    body {
+      font-size: 14px; } }
+  @media screen and (max-width: 768px) {
+    body {
+      font-size: 14px; } }
 
 h2 {
   font-size: 4em; }
@@ -147,8 +154,7 @@ section h2 {
   float: left;
   display: block;
   margin-right: 2.01406%;
-  width: 34.41953%;
-  background: #f9f9f9; }
+  width: 34.41953%; }
   #secondary_data:last-child {
     margin-right: 0; }
   @media screen and (max-width: 768px) {
@@ -159,6 +165,10 @@ section h2 {
       width: 100%; }
       #secondary_data:last-child {
         margin-right: 0; } }
+  #secondary_data h3 {
+    margin-bottom: 0; }
+  #secondary_data h5 {
+    margin-top: 0; }
 
 .section_headline {
   border-top: 1px solid #ccc; }

--- a/css/public_analytics.css
+++ b/css/public_analytics.css
@@ -21,7 +21,7 @@ form .hidden {
   display: none; }
 
 header {
-  background: #022945; }
+  background: #36435A; }
   header .header_container {
     max-width: 68em;
     margin-left: auto;
@@ -31,8 +31,8 @@ header {
       clear: both;
       content: "";
       display: table; }
-  header #red_bar {
-    background: #921B1E;
+  header #color_bar {
+    background: #3A96B7;
     height: 6px; }
   header #logo {
     height: 60px; }
@@ -108,7 +108,7 @@ section h2 {
     font-weight: 300; }
 
 #big_number {
-  color: #921B1E;
+  color: #3A96B7;
   text-align: center; }
 
 figure {
@@ -126,7 +126,7 @@ ul.pills, ul.pills > li {
 ul.pills > li {
   float: left; }
   ul.pills > li > a {
-    color: #022945;
+    color: #36435A;
     background: #f9f9f9;
     font-weight: bold;
     display: inline-block;
@@ -137,7 +137,7 @@ ul.pills > li {
       text-decoration: underline; }
     ul.pills > li > a[aria-selected='true'] {
       color: #fff;
-      background: #022945; }
+      background: #36435A; }
   ul.pills > li:first-child > a {
     border-bottom-left-radius: 5px;
     border-top-left-radius: 5px; }
@@ -164,7 +164,7 @@ ul.pills > li {
     position: absolute !important;
     bottom: 0;
     width: 100%;
-    background: #921B1E; }
+    background: #3A96B7; }
     .bar-chart .bar .value,
     .bar-chart .bar .label {
       display: block;
@@ -201,7 +201,7 @@ table.data {
       line-height: 1em;
       height: 1em;
       position: relative;
-      background: #921B1E; }
+      background: #3A96B7; }
       table.data td.chart .bar .value {
         font-size: 75%;
         position: absolute;
@@ -222,7 +222,7 @@ table.data {
     -webkit-box-sizing: border-box;
     height: 100%;
     border: 2px solid white;
-    background-color: #921B1E; }
+    background-color: #3A96B7; }
     .stack .bin:first-child {
       border-left: none; }
     .stack .bin:last-child {

--- a/css/public_analytics.css
+++ b/css/public_analytics.css
@@ -13,7 +13,7 @@ body {
   font-family: "Open Sans", Helvetica, arial, sans-serif;
   font-size: 16px;
   font-weight: 300;
-  background: #fff;
+  background: #f9f9f9;
   margin: 0; }
   @media screen and (max-width: 992px) {
     body {
@@ -68,8 +68,8 @@ header {
   header h1 {
     float: left;
     display: block;
-    margin-right: 2.01406%;
-    width: 48.99297%;
+    margin-right: 0%;
+    width: 50%;
     font-weight: 300; }
     header h1:last-child {
       margin-right: 0; }
@@ -83,7 +83,7 @@ header {
       header h1 {
         float: left;
         display: block;
-        margin-right: 38.19821%;
+        margin-right: 0%;
         width: 100%; }
         header h1:last-child {
           margin-right: 0; } }
@@ -92,32 +92,37 @@ header {
     font-weight: 300;
     float: left;
     display: block;
-    margin-right: 2.01406%;
-    width: 48.99297%;
+    margin-right: 0%;
+    width: 50%;
     padding-top: 2em;
-    text-align: right; }
+    text-align: right;
+    border: none; }
     header #datetime:last-child {
       margin-right: 0; }
     @media screen and (max-width: 768px) {
       header #datetime {
         float: left;
         display: block;
-        margin-right: 38.19821%;
+        margin-right: 0%;
         width: 100%;
         text-align: left;
         padding-top: 0; }
         header #datetime:last-child {
           margin-right: 0; } }
 
-section h2 {
-  font-size: 8em;
-  margin: 0; }
+section {
+  background: #fff;
+  padding: 1em; }
+  section h2 {
+    font-size: 8em;
+    margin: 0; }
+  section h3 {
+    margin: 10px 0; }
 
 .container {
   max-width: 97.5em;
   margin-left: auto;
-  margin-right: auto;
-  padding: 1em; }
+  margin-right: auto; }
   .container::after {
     clear: both;
     content: "";
@@ -138,32 +143,37 @@ section h2 {
 #main_data {
   float: left;
   display: block;
-  margin-right: 2.01406%;
-  width: 63.56641%; }
+  margin-right: 0%;
+  width: 64.28571%; }
   #main_data:last-child {
     margin-right: 0; }
   @media screen and (max-width: 768px) {
     #main_data {
       float: left;
       display: block;
-      margin-right: 38.19821%;
+      margin-right: 0%;
       width: 100%; }
       #main_data:last-child {
         margin-right: 0; } }
 
 #secondary_data {
+  border-left: 1px solid #ccc;
+  border-right: 1px solid #ccc;
   float: left;
   display: block;
-  margin-right: 2.01406%;
-  width: 34.41953%; }
+  margin-right: 0%;
+  width: 35.71429%; }
   #secondary_data:last-child {
     margin-right: 0; }
   @media screen and (max-width: 768px) {
     #secondary_data {
       float: left;
       display: block;
-      margin-right: 38.19821%;
-      width: 100%; }
+      margin-right: 0%;
+      width: 100%;
+      border-top: 1px solid #ccc;
+      border-left: none;
+      border-right: none; }
       #secondary_data:last-child {
         margin-right: 0; } }
   #secondary_data h3 {
@@ -172,21 +182,30 @@ section h2 {
     margin-top: 0; }
 
 .section_headline {
-  border-top: 1px solid #ccc; }
+  padding: 0 1em;
+  border-left: 1px solid #ccc;
+  border-top: 1px solid #ccc;
+  border-bottom: 1px solid #ccc; }
+  @media screen and (max-width: 768px) {
+    .section_headline {
+      border-bottom: none; } }
 
 .three_column {
   float: left;
   display: block;
-  margin-right: 3.16844%;
-  width: 31.22104%; }
+  margin-right: 0%;
+  width: 33.33333%;
+  border-left: 1px solid #ccc; }
   .three_column:last-child {
     margin-right: 0; }
   @media screen and (max-width: 768px) {
     .three_column {
       float: left;
       display: block;
-      margin-right: 38.19821%;
-      width: 100%; }
+      margin-right: 0%;
+      width: 100%;
+      border-left: none;
+      border-top: 1px solid #ccc; }
       .three_column:last-child {
         margin-right: 0; } }
   .three_column h4 {
@@ -197,8 +216,8 @@ section h2 {
     text-align: center; }
 
 #time_series {
-  text-align: center;
-  margin-bottom: 60px; }
+  border-left: 1px solid #ccc;
+  text-align: center; }
   #time_series .chart_subtitle {
     font-size: 3em;
     font-weight: 300; }

--- a/css/public_analytics.css
+++ b/css/public_analytics.css
@@ -21,7 +21,7 @@ header {
   background: #36435A;
   color: white; }
   header .header_container {
-    max-width: 1560px;
+    max-width: 97.5em;
     margin-left: auto;
     margin-right: auto;
     padding: 0 1em; }
@@ -47,8 +47,8 @@ header {
   header h1 {
     float: left;
     display: block;
-    margin-right: 2.35765%;
-    width: 57.35098%;
+    margin-right: 2.01406%;
+    width: 48.99297%;
     font-weight: 300; }
     header h1:last-child {
       margin-right: 0; }
@@ -71,8 +71,8 @@ header {
     font-weight: 300;
     float: left;
     display: block;
-    margin-right: 2.35765%;
-    width: 40.29137%;
+    margin-right: 2.01406%;
+    width: 34.41953%;
     padding-top: 2em;
     text-align: right; }
     header #datetime:last-child {
@@ -93,7 +93,7 @@ section h2 {
   margin: 0; }
 
 .container {
-  max-width: 1560px;
+  max-width: 97.5em;
   margin-left: auto;
   margin-right: auto;
   padding: 1em; }
@@ -117,8 +117,8 @@ section h2 {
 #main_data {
   float: left;
   display: block;
-  margin-right: 2.35765%;
-  width: 74.41059%; }
+  margin-right: 2.01406%;
+  width: 63.56641%; }
   #main_data:last-child {
     margin-right: 0; }
   @media screen and (max-width: 768px) {
@@ -133,8 +133,8 @@ section h2 {
 #secondary_data {
   float: left;
   display: block;
-  margin-right: 2.35765%;
-  width: 23.23176%;
+  margin-right: 2.01406%;
+  width: 34.41953%;
   background: #f9f9f9; }
   #secondary_data:last-child {
     margin-right: 0; }

--- a/index.html
+++ b/index.html
@@ -28,8 +28,6 @@
     </header>
 
     <div class="container">
-      
-
       <!-- <section id="title">
         <h2>Digital Analytics Dashboard</h2>
         <p>This page provides a summary of federal government website traffic data. It is updated every 5 minutes.</p>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
   <body>
 
     <header id="usa_dot_gov_header">
-      <div id="red_bar"></div>
+      <div id="color_bar"></div>
       <div class="header_container">
         <h1><a href="http://www.usa.gov"><img src="images/usa_gov_logo_white.png" alt="USA.gov: Government Made Easy" id="logo"></a></h1>
         

--- a/index.html
+++ b/index.html
@@ -15,15 +15,16 @@
   <body>
 
     <header id="usa_dot_gov_header">
-      <div id="color_bar"></div>
       <div class="header_container">
-        <h1><a href="http://www.usa.gov"><img src="images/usa_gov_logo_white.png" alt="USA.gov: Government Made Easy" id="logo"></a></h1>
-        
+        <h1><a href="http://www.usa.gov">USA.GOV</a> / Dashboard</h1>
+        <section id="datetime">
+          August 21, 1983 at 6:12pm         
+        </section>
         <!--
         <form action="http://search.usa.gov/search" method="get" name="search_form" accept-charset="UTF-8"><input id="affiliate" name="affiliate" type="hidden" value="usagov"> <label class="hidden">Search</label> <input type="text" class="query" id="query" role="textbox" placeholder="Search USA.gov..."> <input type="submit" class="submit" value="Search"></form>
         -->
       </div>
-
+      <div id="color_bar"></div>
     </header>
 
     <div class="container">

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>GSA Public Analytics</title>
+    <title>Analytics | USA.GOV</title>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=Edge">
     <!--[if lte IE 9]>
@@ -16,7 +16,7 @@
 
     <header id="usa_dot_gov_header">
       <div class="header_container">
-        <h1><a href="http://www.usa.gov">USA.GOV</a> / Dashboard</h1>
+        <h1><a href="http://www.usa.gov">USA.GOV</a> / Analytics</h1>
         <section id="datetime">
           August 21, 1983 at 6:12pm         
         </section>
@@ -127,8 +127,8 @@
 
       <div id="secondary_data">
         <section id="top_100_table">
-          <h3>Top 100 Sites</h3>
-          <h4>By number of sessions over the past 90 days</h4>
+          <h3>Top Sites</h3>
+          <h5>By number of sessions over the past 90 days</h5>
 
           <!-- see: http://heydonworks.com/practical_aria_examples/ -->
           <ul class="pills" role="tablist">

--- a/index.html
+++ b/index.html
@@ -17,9 +17,9 @@
     <header id="usa_dot_gov_header">
       <div class="header_container">
         <h1><a href="http://www.usa.gov">USA.GOV</a> / Analytics</h1>
-        <section id="datetime">
+        <div id="datetime">
           August 21, 1983 at 6:12pm         
-        </section>
+        </div>
         <!--
         <form action="http://search.usa.gov/search" method="get" name="search_form" accept-charset="UTF-8"><input id="affiliate" name="affiliate" type="hidden" value="usagov"> <label class="hidden">Search</label> <input type="text" class="query" id="query" role="textbox" placeholder="Search USA.gov..."> <input type="submit" class="submit" value="Search"></form>
         -->
@@ -127,11 +127,12 @@
 
       <div id="secondary_data">
         <section id="top_100_table">
-          <h3>Top Sites</h3>
-          <h5>By number of sessions over the past 90 days</h5>
+
 
           <!-- see: http://heydonworks.com/practical_aria_examples/ -->
           <ul class="pills" role="tablist">
+            <h3>Top Sites</h3>
+            <h5>By number of sessions over the past 90 days</h5>
             <li><a role="tab" aria-selected="true" href="#top-pages-7-days">7 Days</a></li>
             <li><a role="tab" href="#top-pages-30-days">30 Days</a></li>
             <li><a role="tab" href="#top-pages-90-days">90 Days</a></li>

--- a/index.html
+++ b/index.html
@@ -27,12 +27,14 @@
     </header>
 
     <div class="container">
-      <section id="title">
+      
+
+      <!-- <section id="title">
         <h2>Digital Analytics Dashboard</h2>
         <p>This page provides a summary of federal government website traffic data. It is updated every 5 minutes.</p>
         <p><strong>Please note:</strong> We only have data for 34% of federal websites. <a href="#" title="More information about this data">Click here</a> to learn more.</p>
       </section>
-
+ -->
       <!--
       JavaScript block hooks look for any element with both data-block and
       data-source attributes:
@@ -54,110 +56,115 @@
       </section>
       -->
 
-      <section id="time_series"
-        data-block="users"
-        data-source="https://dap.18f.us/bulk/users.json">
-        <h3>Visitors Over Time</h3>
-        <h4>Total: <span id="big_number" class="data">(big number)</span></h4>
-        <div id="chart_visitors_over_time" class="chart_area">
-          This will be a 24-hour time series chart of traffic to all DAP sites, in 5 minute increments (or maybe hourly, depends on API stuff).
-        </div>
-        <a href="https://dap.18f.us/bulk/users.json">Download this data (JSON)</a>
-      </section>
-
-      <section id="top_100_table">
-        <h3>Top 100 Sites</h3>
-        <h4>By number of sessions over the past 90 days</h4>
-
-        <!-- see: http://heydonworks.com/practical_aria_examples/ -->
-        <ul class="pills" role="tablist">
-          <li><a role="tab" aria-selected="true" href="#top-pages-7-days">7 Days</a></li>
-          <li><a role="tab" href="#top-pages-30-days">30 Days</a></li>
-          <li><a role="tab" href="#top-pages-90-days">90 Days</a></li>
-        </ul>
-
-        <figure id="top-pages-7-days" role="tabpanel"
-          data-block="top-pages"
-          data-source="https://dap.18f.us/bulk/top-pages-7-days.json">
-          <table class="data">
-          </table>
-          <a href="https://dap.18f.us/bulk/top-pages-7-days.json">Download this data (JSON)</a>
-        </figure>
-
-        <figure id="top-pages-30-days" role="tabpanel"
-          data-block="top-pages"
-          data-source="https://dap.18f.us/bulk/top-pages-30-days.json">
-          <table class="data">
-          </table>
-          <a href="https://dap.18f.us/bulk/top-pages-30-days.json">Download this data (JSON)</a>
-        </figure>
-
-        <figure id="top-pages-90-days" role="tabpanel"
-          data-block="top-pages"
-          data-source="https://dap.18f.us/bulk/top-pages-90-days.json">
-          <table class="data">
-          </table>
-          <a href="https://dap.18f.us/bulk/top-pages-90-days.json">Download this data (JSON)</a>
-        </figure>
-      </section>
-
-      <section id="devices" data-block="devices"
-        data-source="https://dap.18f.us/bulk/devices.json">
-        <h3>Traffic by Device Type</h3>
-        <h5>Percentage of All Visitors, Past 90 days</h5>
-        <figure id="chart_device_types">
-          <figcaption>This will be a stacked bar to 100% chart showing how people access federal websites, based on the past 90 days of traffic.</figcaption>
-          <div class="data bar-chart">
+      <div id="main_data">        
+        <section id="time_series"
+          data-block="users"
+          data-source="https://dap.18f.us/bulk/users.json">
+          <h2><span id="big_number" class="data">(big number)</span></h2>
+          <div id="chart_visitors_over_time" class="chart_subtitle">people are online right now
           </div>
-        </figure>
-        <a href="https://dap.18f.us/bulk/devices.json">Download this data (JSON)</a>
-      </section>
+        </section>
 
-      <section id="browsers">
-        <h3>Traffic by Browser</h3>
+        
 
-        <figure id="chart_browsers"
-          data-block="browsers"
-          data-source="https://dap.18f.us/bulk/browsers.json">
-          <figcaption>This chart will show breakdown of browsers from past 90 days. Most important is to show what % of traffic comes from IE.</figcaption>
-          <table class="data">
-          </table>
-          <a href="https://dap.18f.us/bulk/browsers.json">Download this data (JSON)</a>
-        </figure>
+        <section id="devices" class="three_column" data-block="devices"
+          data-source="https://dap.18f.us/bulk/devices.json">
+          <h3>Traffic by Device Type</h3>
+          <h5>Percentage of All Visitors, Past 90 days</h5>
+          <figure id="chart_device_types">
+            <figcaption>This will be a stacked bar to 100% chart showing how people access federal websites, based on the past 90 days of traffic.</figcaption>
+            <div class="data bar-chart">
+            </div>
+          </figure>
+          <a href="https://dap.18f.us/bulk/devices.json">Download this data (JSON)</a>
+        </section>
 
-        <figure id="chart_ie"
-          data-block="ie"
-          data-source="https://dap.18f.us/bulk/ie.json">
-          <h4>Internet Explorer</h4>
-          <figcaption>This chart will show breakdown of browsers from past 90 days. Most important is to show what % of traffic comes from IE.</figcaption>
-          <div class="data bar-chart">
-          </div>
-          <a href="https://dap.18f.us/bulk/browsers.json">Download this data (JSON)</a>
-        </figure>
-      </section>
+        <section id="browsers" class="three_column">
+          <h3>Traffic by Browser</h3>
 
-      <section id="operating_systems">
-        <h3>Traffic by Operating System</h3>
+          <figure id="chart_browsers"
+            data-block="browsers"
+            data-source="https://dap.18f.us/bulk/browsers.json">
+            <figcaption>This chart will show breakdown of browsers from past 90 days. Most important is to show what % of traffic comes from IE.</figcaption>
+            <table class="data">
+            </table>
+            <a href="https://dap.18f.us/bulk/browsers.json">Download this data (JSON)</a>
+          </figure>
 
-        <figure id="chart_operating_system"
-          data-block="os"
-          data-source="https://dap.18f.us/bulk/os.json">
-          <figcaption>This chart will show breakdown of operating systems from past 90 days.</figcaption>
-          <table class="data">
-          </table>
-          <a href="https://dap.18f.us/bulk/os.json">Download this data (JSON)</a>
-        </figure>
+          <figure id="chart_ie"
+            data-block="ie"
+            data-source="https://dap.18f.us/bulk/ie.json">
+            <h4>Internet Explorer</h4>
+            <figcaption>This chart will show breakdown of browsers from past 90 days. Most important is to show what % of traffic comes from IE.</figcaption>
+            <div class="data bar-chart">
+            </div>
+            <a href="https://dap.18f.us/bulk/browsers.json">Download this data (JSON)</a>
+          </figure>
+        </section>
 
-        <figure id="chart_windows"
-          data-block="windows"
-          data-source="https://dap.18f.us/bulk/windows.json">
-          <h4>Windows</h4>
-          <figcaption>This chart will show breakdown of OS versions used by Windows visitors. Most important is to show what % of traffic comes from XP.</figcaption>
-          <div class="data bar-chart">
-          </div>
-          <a href="https://dap.18f.us/bulk/windows.json">Download this data (JSON)</a>
-        </figure>
-      </section>
+        <section id="operating_systems" class="three_column">
+          <h3>Traffic by Operating System</h3>
+
+          <figure id="chart_operating_system"
+            data-block="os"
+            data-source="https://dap.18f.us/bulk/os.json">
+            <figcaption>This chart will show breakdown of operating systems from past 90 days.</figcaption>
+            <table class="data">
+            </table>
+            <a href="https://dap.18f.us/bulk/os.json">Download this data (JSON)</a>
+          </figure>
+
+          <figure id="chart_windows"
+            data-block="windows"
+            data-source="https://dap.18f.us/bulk/windows.json">
+            <h4>Windows</h4>
+            <figcaption>This chart will show breakdown of OS versions used by Windows visitors. Most important is to show what % of traffic comes from XP.</figcaption>
+            <div class="data bar-chart">
+            </div>
+            <a href="https://dap.18f.us/bulk/windows.json">Download this data (JSON)</a>
+          </figure>
+        </section>
+      </div>
+
+      <div id="secondary_data">
+        <section id="top_100_table">
+          <h3>Top 100 Sites</h3>
+          <h4>By number of sessions over the past 90 days</h4>
+
+          <!-- see: http://heydonworks.com/practical_aria_examples/ -->
+          <ul class="pills" role="tablist">
+            <li><a role="tab" aria-selected="true" href="#top-pages-7-days">7 Days</a></li>
+            <li><a role="tab" href="#top-pages-30-days">30 Days</a></li>
+            <li><a role="tab" href="#top-pages-90-days">90 Days</a></li>
+          </ul>
+
+          <figure id="top-pages-7-days" role="tabpanel"
+            data-block="top-pages"
+            data-source="https://dap.18f.us/bulk/top-pages-7-days.json">
+            <table class="data">
+            </table>
+            <a href="https://dap.18f.us/bulk/top-pages-7-days.json">Download this data (JSON)</a>
+          </figure>
+
+          <figure id="top-pages-30-days" role="tabpanel"
+            data-block="top-pages"
+            data-source="https://dap.18f.us/bulk/top-pages-30-days.json">
+            <table class="data">
+            </table>
+            <a href="https://dap.18f.us/bulk/top-pages-30-days.json">Download this data (JSON)</a>
+          </figure>
+
+          <figure id="top-pages-90-days" role="tabpanel"
+            data-block="top-pages"
+            data-source="https://dap.18f.us/bulk/top-pages-90-days.json">
+            <table class="data">
+            </table>
+            <a href="https://dap.18f.us/bulk/top-pages-90-days.json">Download this data (JSON)</a>
+          </figure>
+        </section>
+      </div>
+
+
 
     </div>
   </body>

--- a/index.html
+++ b/index.html
@@ -65,13 +65,13 @@
         </section>
 
         
+        <section class="section_headline"><h3>Technology</h3></section>
 
         <section id="devices" class="three_column" data-block="devices"
           data-source="https://dap.18f.us/bulk/devices.json">
-          <h3>Traffic by Device Type</h3>
+          <h4>Device</h4>
           <h5>Percentage of All Visitors, Past 90 days</h5>
           <figure id="chart_device_types">
-            <figcaption>This will be a stacked bar to 100% chart showing how people access federal websites, based on the past 90 days of traffic.</figcaption>
             <div class="data bar-chart">
             </div>
           </figure>
@@ -79,12 +79,12 @@
         </section>
 
         <section id="browsers" class="three_column">
-          <h3>Traffic by Browser</h3>
+          <h4>Browser</h4>
+          <h5>Percentage of All Visitors, Past 90 days</h5>
 
           <figure id="chart_browsers"
             data-block="browsers"
             data-source="https://dap.18f.us/bulk/browsers.json">
-            <figcaption>This chart will show breakdown of browsers from past 90 days. Most important is to show what % of traffic comes from IE.</figcaption>
             <table class="data">
             </table>
             <a href="https://dap.18f.us/bulk/browsers.json">Download this data (JSON)</a>
@@ -102,7 +102,8 @@
         </section>
 
         <section id="operating_systems" class="three_column">
-          <h3>Traffic by Operating System</h3>
+          <h4>Operating System</h4>
+          <h5>Percentage of All Visitors, Past 90 days</h5>
 
           <figure id="chart_operating_system"
             data-block="os"
@@ -117,7 +118,6 @@
             data-block="windows"
             data-source="https://dap.18f.us/bulk/windows.json">
             <h4>Windows</h4>
-            <figcaption>This chart will show breakdown of OS versions used by Windows visitors. Most important is to show what % of traffic comes from XP.</figcaption>
             <div class="data bar-chart">
             </div>
             <a href="https://dap.18f.us/bulk/windows.json">Download this data (JSON)</a>

--- a/sass/public_analytics.css.scss
+++ b/sass/public_analytics.css.scss
@@ -1,48 +1,50 @@
 @import "bourbon/bourbon";
 @import "neat/neat";
 
-// Screen Sizes: 
-
-$xlarge-screen:  new-breakpoint(max-width  1600px  12);
-$large-screen:  new-breakpoint(max-width 1200px 12);
-$medium-screen: new-breakpoint(max-width  992px 12);
-$small-screen:  new-breakpoint(max-width  768px  1);
-
-$max-width: 1560px;
+//Grid Settings:
+$grid-columns: 14;
+$max-width: em(1560);
 
 @mixin responsive_container {
-    @include outer-container;
+  @include outer-container;
 
-    @include media($xlarge-screen) {
-      max-width: 1560px;
-    }
-    @include media($large-screen)  {
-      max-width: 1170px;
-    }
-    @include media($medium-screen) {
-      max-width:  970px;
-    }
-    @include media($small-screen)  {
-      max-width:  750px;
-    }
+  @include media($xlarge-screen) {
+    max-width: 1560px;
   }
+  @include media($large-screen)  {
+    max-width: 1170px;
+  }
+  @include media($medium-screen) {
+    max-width:  970px;
+  }
+  @include media($small-screen)  {
+    max-width:  750px;
+    $em-base: 12px;
+  }
+}
 
+$xlarge-screen:  new-breakpoint(max-width  1600px  14);
+$large-screen:  new-breakpoint(max-width 1200px 14);
+$medium-screen: new-breakpoint(max-width  992px 14);
+$small-screen:  new-breakpoint(max-width  768px  1);
 
 // Fonts & Colors:
 @import url(//fonts.googleapis.com/css?family=Open+Sans:400,600,700,300);
 
-$background_color: $white;
-$container_background: $white;
 $red: #921B1E;
 $blue: #022945;
 $light_gray: #f9f9f9;
 $light_blue: #3A96B7;
 $dark_blue: #36435A;
 $white: #fff;
+$background_color: $white;
+$container_background: $white;
 
 $bold_weight: 600;
 
 $data: $light_blue;
+
+
 
 
 // Other Setup:
@@ -122,7 +124,7 @@ section {
 }
 
 #secondary_data {
-  @include span-columns(3);
+  @include span-columns(5);
   background: $light_gray;
 
   @include media($small-screen)  {

--- a/sass/public_analytics.css.scss
+++ b/sass/public_analytics.css.scss
@@ -1,22 +1,51 @@
 @import "bourbon/bourbon";
 @import "neat/neat";
 
+// Screen Sizes: 
+
+$xlarge-screen:  new-breakpoint(max-width  1600px  12);
+$large-screen:  new-breakpoint(max-width 1200px 12);
+$medium-screen: new-breakpoint(max-width  992px 12);
+$small-screen:  new-breakpoint(max-width  768px  1);
+
+$max-width: 1560px;
+
+@mixin responsive_container {
+    @include outer-container;
+
+    @include media($xlarge-screen) {
+      max-width: 1560px;
+    }
+    @include media($large-screen)  {
+      max-width: 1170px;
+    }
+    @include media($medium-screen) {
+      max-width:  970px;
+    }
+    @include media($small-screen)  {
+      max-width:  750px;
+    }
+  }
+
+
+// Fonts & Colors:
 @import url(//fonts.googleapis.com/css?family=Open+Sans:400,600,700,300);
 
-// Colors:
-
-$background_color: #fff;
-$container_background: #fff;
-$mockup: #eee;
+$background_color: $white;
+$container_background: $white;
 $red: #921B1E;
 $blue: #022945;
 $light_gray: #f9f9f9;
-
 $light_blue: #3A96B7;
 $dark_blue: #36435A;
+$white: #fff;
 
-$data: $light_blue; // FIXME
+$bold_weight: 600;
 
+$data: $light_blue;
+
+
+// Other Setup:
 $border_radius: 5px;
 
 body {
@@ -29,18 +58,12 @@ h2 {
   font-size: 4em;
 }
 
-form {
-  .hidden {
-    display: none;
-  }
-}
-
 header {
   background: $dark_blue;
   color: white;
 
   .header_container {
-    @include outer-container;
+    @include responsive_container;
     padding: 0 1em;
   }
 
@@ -49,17 +72,19 @@ header {
     height: 6px;
   }
 
-
   h1 {
     @include span-columns(7);
     font-weight: 300;
     a {
-      font-weight: 600;
+      font-weight: $bold_weight;
       color: white;
       text-decoration: none;
     }
     a:hover {
       text-decoration: underline;
+    }
+    @include media($small-screen)  {
+      @include span-columns(1);
     }
   }
 
@@ -69,30 +94,12 @@ header {
     @include span-columns(5);
     padding-top: 2em;
     text-align: right;
+    @include media($small-screen)  {
+      @include span-columns(1);
+      text-align: left;
+      padding-top: 0;
+    }
   }
-
-
-  // Unused for now:
-  // #logo {
-  //   height: 60px;
-  // }
-  
-  // form {
-  //   @include span-columns(5);
-  //   input {
-  //     height: 40px;
-  //     font-size: 1em;
-  //   }
-  //   input.query {
-  //     width: 70%;
-  //   }
-  //   input.submit {
-  //     width: 25%;
-  //     padding: 0;
-  //   }
-  //   margin: 35px 0;
-  //   height: 40px;
-  // }
 }
 
 section {
@@ -103,21 +110,31 @@ section {
 }
 
 .container {
-  @include outer-container;
+  @include responsive_container;
   padding: 1em;
 }
 
 #main_data {
   @include span-columns(9);
+  @include media($small-screen)  {
+    @include span-columns(1);
+  }
 }
 
 #secondary_data {
   @include span-columns(3);
   background: $light_gray;
+
+  @include media($small-screen)  {
+    @include span-columns(1);
+  }
 }
 
 .three_column {
   @include span-columns(3 of 9);
+  @include media($small-screen)  {
+    @include span-columns(1);
+  }
 }
 
 
@@ -131,7 +148,7 @@ section {
 }
 
 #big_number {
-  color: $data;
+  font-weight: $bold_weight;
   text-align: center;
 }
 
@@ -307,3 +324,4 @@ table.data {
     }
   }
 }
+

--- a/sass/public_analytics.css.scss
+++ b/sass/public_analytics.css.scss
@@ -12,7 +12,10 @@ $red: #921B1E;
 $blue: #022945;
 $light_gray: #f9f9f9;
 
-$data: $red; // FIXME
+$light_blue: #3A96B7;
+$dark_blue: #36435A;
+
+$data: $light_blue; // FIXME
 
 $border_radius: 5px;
 
@@ -33,15 +36,15 @@ form {
 }
 
 header {
-  background: $blue;
+  background: $dark_blue;
 
   .header_container {
     @include outer-container;
     padding: 0 1em;
   }
 
-  #red_bar {
-    background: $red;
+  #color_bar {
+    background: $light_blue;
     height: 6px;
   }
 
@@ -132,7 +135,7 @@ ul.pills {
     float: left;
 
     & > a {
-      color: $blue;
+      color: $dark_blue;
       background: $light_gray;
       font-weight: bold;
       display: inline-block;
@@ -147,7 +150,7 @@ ul.pills {
 
       &[aria-selected='true'] {
         color: #fff;
-        background: $blue;
+        background: $dark_blue;
       }
     }
 

--- a/sass/public_analytics.css.scss
+++ b/sass/public_analytics.css.scss
@@ -1,7 +1,7 @@
 @import "bourbon/bourbon";
 @import "neat/neat";
 
-@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700,300);
+@import url(//fonts.googleapis.com/css?family=Open+Sans:400,700,300);
 
 // Colors:
 
@@ -17,7 +17,7 @@ $data: $red; // FIXME
 $border_radius: 5px;
 
 body {
-  font-family: "Source Sans Pro", Helvetica, arial, sans-serif;
+  font-family: "Open Sans", Helvetica, arial, sans-serif;
   background: $background_color;
   margin: 0;
 }
@@ -72,16 +72,9 @@ header {
 }
 
 section {
-  @include span-columns(12);
-
   h2 {
-    font-size: 4em;
-    @include span-columns(7);
+    font-size: 8em;
     margin: 0;
-  }
-
-  p {
-    @include span-columns(8);
   }
 }
 
@@ -90,8 +83,32 @@ section {
   padding: 1em;
 }
 
+#main_data {
+  @include span-columns(9);
+}
+
+#secondary_data {
+  @include span-columns(3);
+  background: $light_gray;
+}
+
+.three_column {
+  @include span-columns(3 of 9);
+}
+
+
+#time_series {
+  text-align: center;
+  .chart_subtitle {
+    font-size: 3em;
+    font-weight: 300;
+  }
+  margin-bottom: 60px;
+}
+
 #big_number {
   color: $data;
+  text-align: center;
 }
 
 table.data td.chart .bar {

--- a/sass/public_analytics.css.scss
+++ b/sass/public_analytics.css.scss
@@ -51,6 +51,7 @@ body {
   font-family: "Open Sans", Helvetica, arial, sans-serif;
   font-size: 16px;
   $em-size: 16px;
+  font-weight: 300;
   background: $background_color;
   margin: 0;
   @include media($medium-screen) {

--- a/sass/public_analytics.css.scss
+++ b/sass/public_analytics.css.scss
@@ -19,7 +19,6 @@ $max-width: em(1560);
   }
   @include media($small-screen)  {
     max-width:  750px;
-    $em-base: 12px;
   }
 }
 
@@ -50,8 +49,16 @@ $border_radius: 5px;
 
 body {
   font-family: "Open Sans", Helvetica, arial, sans-serif;
+  font-size: 16px;
+  $em-size: 16px;
   background: $background_color;
   margin: 0;
+  @include media($medium-screen) {
+    font-size: 14px;
+  }
+  @include media($small-screen) {
+    font-size: 14px;
+  }
 }
 
 h2 {
@@ -139,10 +146,15 @@ section {
 
 #secondary_data {
   @include span-columns(5);
-  background: $light_gray;
-
   @include media($small-screen)  {
     @include span-columns(1);
+  }
+
+  h3 {
+    margin-bottom: 0;
+  }
+  h5 {
+    margin-top: 0;
   }
 }
 

--- a/sass/public_analytics.css.scss
+++ b/sass/public_analytics.css.scss
@@ -1,9 +1,12 @@
 @import "bourbon/bourbon";
-@import "neat/neat";
 
 //Grid Settings:
 $grid-columns: 14;
 $max-width: em(1560);
+$gutter: 0em !global;
+
+@import "neat/neat";
+
 
 @mixin responsive_container {
   @include outer-container;
@@ -37,7 +40,7 @@ $gray: #ccc;
 $light_blue: #3A96B7;
 $dark_blue: #36435A;
 $white: #fff;
-$background_color: $white;
+$background_color: $light_gray;
 $container_background: $white;
 
 $bold_weight: 600;
@@ -118,6 +121,7 @@ header {
     @include span-columns(7);
     padding-top: 2em;
     text-align: right;
+    border: none;
     @include media($small-screen)  {
       @include span-columns(1);
       text-align: left;
@@ -127,15 +131,19 @@ header {
 }
 
 section {
+  background: $white;
+  padding: 1em;
   h2 {
     font-size: 8em;
     margin: 0;
+  }
+  h3 {
+    margin: 10px 0;
   }
 }
 
 .container {
   @include responsive_container;
-  padding: 1em;
 }
 
 #main_data {
@@ -146,9 +154,14 @@ section {
 }
 
 #secondary_data {
+  border-left: 1px solid $gray;
+  border-right: 1px solid $gray;
   @include span-columns(5);
   @include media($small-screen)  {
     @include span-columns(1);
+    border-top: 1px solid $gray;
+    border-left: none;
+    border-right: none;
   }
 
   h3 {
@@ -160,13 +173,24 @@ section {
 }
 
 .section_headline {
+  padding: 0 1em;
+  border-left: 1px solid $gray;
   border-top: 1px solid $gray;
+  border-bottom: 1px solid $gray;
+  @include media($small-screen)  {
+    border-bottom: none;
+  }
+  // border-left: 1px solid $gray;
 }
 
 .three_column {
   @include span-columns(3 of 9);
+  border-left: 1px solid $gray;
+
   @include media($small-screen)  {
     @include span-columns(1);
+    border-left: none;
+    border-top: 1px solid $gray;
   }
   h4 {
     text-align: center;
@@ -178,14 +202,13 @@ section {
   }
 }
 
-
 #time_series {
+  border-left: 1px solid $gray;
   text-align: center;
   .chart_subtitle {
     font-size: 3em;
     font-weight: 300;
   }
-  margin-bottom: 60px;
 }
 
 #big_number {

--- a/sass/public_analytics.css.scss
+++ b/sass/public_analytics.css.scss
@@ -1,7 +1,7 @@
 @import "bourbon/bourbon";
 @import "neat/neat";
 
-@import url(//fonts.googleapis.com/css?family=Open+Sans:400,700,300);
+@import url(//fonts.googleapis.com/css?family=Open+Sans:400,600,700,300);
 
 // Colors:
 
@@ -37,6 +37,7 @@ form {
 
 header {
   background: $dark_blue;
+  color: white;
 
   .header_container {
     @include outer-container;
@@ -48,30 +49,50 @@ header {
     height: 6px;
   }
 
-  #logo {
-    height: 60px;
-  }
 
   h1 {
     @include span-columns(7);
+    font-weight: 300;
+    a {
+      font-weight: 600;
+      color: white;
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
   }
 
-  form {
+  #datetime {
+    font-size: 1em;
+    font-weight: 300;
     @include span-columns(5);
-    input {
-      height: 40px;
-      font-size: 1em;
-    }
-    input.query {
-      width: 70%;
-    }
-    input.submit {
-      width: 25%;
-      padding: 0;
-    }
-    margin: 35px 0;
-    height: 40px;
+    padding-top: 2em;
+    text-align: right;
   }
+
+
+  // Unused for now:
+  // #logo {
+  //   height: 60px;
+  // }
+  
+  // form {
+  //   @include span-columns(5);
+  //   input {
+  //     height: 40px;
+  //     font-size: 1em;
+  //   }
+  //   input.query {
+  //     width: 70%;
+  //   }
+  //   input.submit {
+  //     width: 25%;
+  //     padding: 0;
+  //   }
+  //   margin: 35px 0;
+  //   height: 40px;
+  // }
 }
 
 section {

--- a/sass/public_analytics.css.scss
+++ b/sass/public_analytics.css.scss
@@ -34,6 +34,7 @@ $small-screen:  new-breakpoint(max-width  768px  1);
 $red: #921B1E;
 $blue: #022945;
 $light_gray: #f9f9f9;
+$gray: #ccc;
 $light_blue: #3A96B7;
 $dark_blue: #36435A;
 $white: #fff;
@@ -43,9 +44,6 @@ $container_background: $white;
 $bold_weight: 600;
 
 $data: $light_blue;
-
-
-
 
 // Other Setup:
 $border_radius: 5px;
@@ -58,6 +56,22 @@ body {
 
 h2 {
   font-size: 4em;
+}
+
+h3 {
+  font-size: 1.2em;
+  margin: 1em 0;
+}
+
+h4 {
+  margin: 1em 0;
+  font-size: 1.2em;
+  font-weight: 400;
+}
+
+h5 {
+  font-size: 0.8em;
+  font-weight: 400;
 }
 
 header {
@@ -93,7 +107,7 @@ header {
   #datetime {
     font-size: 1em;
     font-weight: 300;
-    @include span-columns(5);
+    @include span-columns(7);
     padding-top: 2em;
     text-align: right;
     @include media($small-screen)  {
@@ -132,10 +146,22 @@ section {
   }
 }
 
+.section_headline {
+  border-top: 1px solid $gray;
+}
+
 .three_column {
   @include span-columns(3 of 9);
   @include media($small-screen)  {
     @include span-columns(1);
+  }
+  h4 {
+    text-align: center;
+    margin: 0;
+  }
+  h5 {
+    margin-top: 0;
+    text-align: center;
   }
 }
 


### PR DESCRIPTION
This PR begins to implement the design direction @rypan suggested. It also includes @shawnbot's potential concept of the "tech" stats being in three columns. I haven't yet implemented the responsive flow, but the idea is that it would switch to a single column layout with the "top 100" sites going to the bottom.

It looks like this now: 

![image](https://cloud.githubusercontent.com/assets/1237498/5714194/4804000e-9a93-11e4-8bfb-f57bb15cd91b.png)
